### PR TITLE
Bench Prefix Iterator

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -47,6 +47,37 @@ func String(s string) *string {
 	return &s
 }
 
+func testObjWithSuffix(suf string) *TestObject {
+	b := true
+	obj := &TestObject{
+		ID:  "my-cool-obj" + suf,
+		Foo: "Testing",
+		Fu:  String("Fu"),
+		Boo: nil,
+		Bar: 42,
+		Baz: "yep",
+		Bam: &b,
+		Qux: []string{"Test", "Test2"},
+		Zod: map[string]string{
+			"Role":          "Server",
+			"instance_type": "m3.medium",
+			"":              "asdf",
+		},
+		Int:    int(1),
+		Int8:   int8(-1 << 7),
+		Int16:  int16(-1 << 15),
+		Int32:  int32(-1 << 31),
+		Int64:  int64(-1 << 63),
+		Uint:   uint(1),
+		Uint8:  uint8(1<<8 - 1),
+		Uint16: uint16(1<<16 - 1),
+		Uint32: uint32(1<<32 - 1),
+		Uint64: uint64(1<<64 - 1),
+		Bool:   false,
+	}
+	return obj
+}
+
 func testObj() *TestObject {
 	b := true
 	obj := &TestObject{

--- a/memdb_test.go
+++ b/memdb_test.go
@@ -4,6 +4,7 @@
 package memdb
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -80,5 +81,22 @@ func TestMemDB_Snapshot(t *testing.T) {
 	}
 	if out == nil {
 		t.Fatalf("should exist")
+	}
+}
+
+func BenchmarkMemDB_Snapshot(b *testing.B) {
+	db, err := NewMemDB(testValidSchema())
+	if err != nil {
+		b.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		// Add an object
+		obj := testObjWithSuffix(strconv.Itoa(i))
+		txn := db.Txn(true)
+		txn.Insert("main", obj)
+		txn.Commit()
+		// Clone the db
+		db.Snapshot()
 	}
 }

--- a/memdb_test.go
+++ b/memdb_test.go
@@ -96,7 +96,7 @@ func BenchmarkMemDB_Snapshot(b *testing.B) {
 		txn := db.Txn(true)
 		txn.Insert("main", obj)
 		txn.Commit()
-		// Clone the db
-		db.Snapshot()
 	}
+	// Clone the db
+	db.Snapshot()
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -2248,13 +2248,11 @@ func BenchmarkTxnIterator(b *testing.B) {
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}
-
 		result, err := txn.Get("main", "id")
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}
 		for itr := result.Next(); itr != nil; itr = result.Next() {
-
 		}
 	}
 }

--- a/txn_test.go
+++ b/txn_test.go
@@ -2249,7 +2249,7 @@ func BenchmarkTxnIterator(b *testing.B) {
 			b.Fatalf("err: %v", err)
 		}
 
-		result, err := txn.Get("main", "id")
+		result, err := txn.Get("main", "id", obj.ID)
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}

--- a/txn_test.go
+++ b/txn_test.go
@@ -2249,7 +2249,7 @@ func BenchmarkTxnIterator(b *testing.B) {
 			b.Fatalf("err: %v", err)
 		}
 
-		result, err := txn.Get("main", "id", obj.ID)
+		result, err := txn.Get("main", "id")
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}

--- a/txn_test.go
+++ b/txn_test.go
@@ -2237,7 +2237,7 @@ func testDBB(b *testing.B) *MemDB {
 	return db
 }
 
-func BenchmarkTxnInsert(b *testing.B) {
+func BenchmarkTxnIterator(b *testing.B) {
 	db := testDBB(b)
 	txn := db.Txn(true)
 

--- a/txn_test.go
+++ b/txn_test.go
@@ -6,6 +6,7 @@ package memdb
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -2240,14 +2241,15 @@ func BenchmarkTxnInsert(b *testing.B) {
 	db := testDBB(b)
 	txn := db.Txn(true)
 
-	obj := testObj()
 	for i := 0; i < b.N; i++ {
+		sti := strconv.Itoa(i)
+		obj := testObjWithSuffix(sti)
 		err := txn.Insert("main", obj)
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}
 
-		result, err := txn.Get("main", "id", obj.ID)
+		result, err := txn.Get("main", "id")
 		if err != nil {
 			b.Fatalf("err: %v", err)
 		}

--- a/txn_test.go
+++ b/txn_test.go
@@ -2231,3 +2231,28 @@ func assertNilError(t *testing.T, err error) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }
+func testDBB(b *testing.B) *MemDB {
+	db, _ := NewMemDB(testValidSchema())
+	return db
+}
+
+func BenchmarkTxnInsert(b *testing.B) {
+	db := testDBB(b)
+	txn := db.Txn(true)
+
+	obj := testObj()
+	for i := 0; i < b.N; i++ {
+		err := txn.Insert("main", obj)
+		if err != nil {
+			b.Fatalf("err: %v", err)
+		}
+
+		result, err := txn.Get("main", "id", obj.ID)
+		if err != nil {
+			b.Fatalf("err: %v", err)
+		}
+		for itr := result.Next(); itr != nil; itr = result.Next() {
+
+		}
+	}
+}


### PR DESCRIPTION
```
⚡️ ~/memdb-master (bench) » go test -bench=BenchmarkTxnIterator -benchtime=3s -benchmem -cpuprofile=cpu.prof -memprofile mem.prof
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/go-memdb
BenchmarkTxnIterator-12    	   93494	    754699 ns/op	    5728 B/op	      94 allocs/op
PASS
ok  	github.com/hashicorp/go-memdb	73.683s
```
Benchmark after changes in https://github.com/hashicorp/go-immutable-radix/pull/57  

```
⚡️ ~/memdb-master (optimized-seek-prefix) » go test -bench=BenchmarkTxnIterator -benchtime=3s -benchmem -cpuprofile=cpu.prof -memprofile mem.prof
goos: darwin
goarch: arm64
pkg: github.com/absolutelightning/go-memdb
BenchmarkTxnIterator-12    	   78452	    313244 ns/op	    5653 B/op	      89 allocs/op
PASS
ok  	github.com/absolutelightning/go-memdb	28.584s
```